### PR TITLE
Replace deprecated CLGeocoder with MKReverseGeocodingRequest

### DIFF
--- a/WiFiCheck/Info.plist
+++ b/WiFiCheck/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>261</string>
+	<string>262</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/WiFiCheck/WiFiDataDetail.swift
+++ b/WiFiCheck/WiFiDataDetail.swift
@@ -23,22 +23,16 @@ final class GeocodeCache {
         String(format: "%.4f,%.4f", lat, lon)
     }
 
-    /// Returns a cached place name immediately, or performs a reverse geocode and caches the result.
-    /// Completion is always called on the main queue.
-    func resolve(lat: Double, lon: Double, completion: @escaping (String?) -> Void) {
+    /// Returns a cached place name, or performs a reverse geocode and caches the result.
+    func resolve(lat: Double, lon: Double) async -> String? {
         let k = key(lat: lat, lon: lon)
-        if let cached = cache[k] {
-            completion(cached)
-            return
-        }
-        CLGeocoder().reverseGeocodeLocation(CLLocation(latitude: lat, longitude: lon)) { [self] placemarks, _ in
-            let parts = [placemarks?.first?.locality,
-                         placemarks?.first?.administrativeArea,
-                         placemarks?.first?.country].compactMap { $0 }
-            let name = parts.isEmpty ? nil : parts.joined(separator: ", ")
-            if let name { self.cache[k] = name }
-            DispatchQueue.main.async { completion(name) }
-        }
+        if let cached = cache[k] { return cached }
+        guard let request = MKReverseGeocodingRequest(location: CLLocation(latitude: lat, longitude: lon)),
+              let mapItems = try? await request.mapItems,
+              let item = mapItems.first else { return nil }
+        let name = item.address?.shortAddress ?? item.address?.fullAddress
+        if let name { cache[k] = name }
+        return name
     }
 }
 
@@ -578,8 +572,8 @@ struct BSSLocationMapView: View {
             }
         }
         .onAppear {
-            GeocodeCache.shared.resolve(lat: latitude, lon: longitude) { name in
-                placeName = name
+            Task {
+                placeName = await GeocodeCache.shared.resolve(lat: latitude, lon: longitude)
             }
         }
         .sheet(isPresented: $showExpanded) {


### PR DESCRIPTION
## Summary
- Replaces `CLGeocoder` and `reverseGeocodeLocation(_:completionHandler:)` (both deprecated in macOS 26) with `MKReverseGeocodingRequest`
- Converts `GeocodeCache.resolve` from a completion-handler pattern to `async`/`await`
- Replaces deprecated `MKMapItem.placemark` with `address.shortAddress` / `fullAddress`
- Call site in `BSSLocationMapView.onAppear` updated to use a `Task` block

## Test plan
- [ ] Build with macOS 26 SDK — confirm zero deprecation warnings in `WiFiDataDetail.swift`
- [ ] Open a network entry that has BSS location data and verify the geocoded place name still appears correctly below the map thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)